### PR TITLE
Add pricing plans section and related styles

### DIFF
--- a/index.css
+++ b/index.css
@@ -437,3 +437,82 @@ body {
         text-align: center;
     }
 }
+
+/* ==========================
+   Plans / Pricing Cards
+   ========================== */
+
+:root{
+  --plans-bg: #0f1720;
+  --card-bg: #f7f7f7;
+  --card-text: #0b1220;
+  --muted: #475569;
+}
+
+#plans-section{
+  background: var(--plans-bg);
+  color: #fff;
+  padding: 3rem 1rem;
+}
+
+#plans-section .container{
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.plans-title{
+  font-size: 2rem;
+  margin-bottom: 1.25rem;
+  color: #fff;
+}
+
+/*. Grid: 3 columns desktop, 2 tablet, 1 mobile */
+.plans-grid{
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.plan{
+  background: var(--card-bg);
+  color: var(--card-text);
+  padding: 1.25rem;
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(2,6,23,0.15);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 160px;
+  position: relative;
+  overflow: hidden;
+  transition: transform 300ms ease, box-shadow 300ms ease;
+}
+
+.plan:focus{outline: 2px solid rgba(99,102,241,0.25);}
+
+.plan:hover,
+.plan:focus-within{
+  transform: translateY(-6px) scale(1.01);
+  box-shadow: 0 12px 30px rgba(2,6,23,0.2);
+}
+
+.plan-body{gap:.5rem; display:flex; flex-direction:column}
+.plan-title{font-size:1.125rem; margin-bottom:.25rem; font-weight:700}
+.plan-sub{font-weight:700; color:var(--card-text); margin-bottom:.5rem}
+.plan-desc{color:var(--muted); font-size:.95rem; line-height:1.3}
+
+.plan-footer{
+  font-size: 1.2rem;
+  color:#9ca3af;
+  align-self: flex-end;
+  transition: transform 300ms ease, color 300ms ease;
+}
+.plan:hover .plan-footer{ transform: translateX(8px); color:#6b7280; }
+
+/* RTL: arrow on left and translate the opposite direction */
+html[dir="rtl"] .plan-footer { align-self: flex-start; transform: none; }
+html[dir="rtl"] .plan:hover .plan-footer{ transform: translateX(-8px); }
+
+@media (max-width: 1024px){ .plans-grid{ grid-template-columns: repeat(2,1fr); } }
+@media (max-width: 640px){ .plans-grid{ grid-template-columns: 1fr; } }

--- a/index.html
+++ b/index.html
@@ -64,16 +64,71 @@
         </section>
 
 
-        <section id="testimonials">
-            <article id="testimonial-1">
-                <blockquote>"DollarTrack AI שינה את האופן בו אני מנהל את תיק המט\"ח שלי."</blockquote>
-                <cite>איתמר מזרחי, אנליסט פיננסי</cite>
-            </article>
-            <article id="testimonial-2">
-                <blockquote>"תחזיות ה-AI מדויקות בצורה מפחידה."</blockquote>
-                <cite>נחום trustMe, סוחר יומי</cite>
-            </article>
-        </section>
+                <section id="testimonials">
+                        <article id="testimonial-1">
+                                <blockquote>"DollarTrack AI שינה את האופן בו אני מנהל את תיק המט\"ח שלי."</blockquote>
+                                <cite>איתמר מזרחי, אנליסט פיננסי</cite>
+                        </article>
+                        <article id="testimonial-2">
+                                <blockquote>"תחזיות ה-AI מדויקות בצורה מפחידה."</blockquote>
+                                <cite>נחום trustMe, סוחר יומי</cite>
+                        </article>
+                </section>
+
+                <!-- Pricing / Plans section (cards grid) -->
+                <section id="plans-section" aria-label="Choose your plan">
+                    <div class="container">
+                        <h2 class="plans-title">בחר תוכנית</h2>
+
+                        <div class="plans-grid">
+                            <article class="plan" tabindex="0">
+                                <div class="plan-body">
+                                    <h3 class="plan-title">Standard</h3>
+                                    <p class="plan-sub">חינם</p>
+                                    <p class="plan-desc">רק לראות את הנתונים הבסיסיים.</p>
+                                </div>
+                                <div class="plan-footer" aria-hidden="true">→</div>
+                            </article>
+
+                            <article class="plan" tabindex="0">
+                                <div class="plan-body">
+                                    <h3 class="plan-title">Plus</h3>
+                                    <p class="plan-sub">₪12.90/חודש</p>
+                                    <p class="plan-desc">גישה לתכונות מתקדמות יותר ולתמיכה משופרת.</p>
+                                </div>
+                                <div class="plan-footer" aria-hidden="true">→</div>
+                            </article>
+
+                            <article class="plan" tabindex="0">
+                                <div class="plan-body">
+                                    <h3 class="plan-title">Premium</h3>
+                                    <p class="plan-sub">₪29.90/חודש</p>
+                                    <p class="plan-desc">גישה לנקודות ושירותים פרימיום להחלפת כספים ללא הגבלה.</p>
+                                </div>
+                                <div class="plan-footer" aria-hidden="true">→</div>
+                            </article>
+
+                            <article class="plan" tabindex="0">
+                                <div class="plan-body">
+                                    <h3 class="plan-title">Metal</h3>
+                                    <p class="plan-sub">₪59.90/חודש</p>
+                                    <p class="plan-desc">גישה לתכונות פרימיום ולתמיכה משופרת.</p>
+                                </div>
+                                <div class="plan-footer" aria-hidden="true">→</div>
+                            </article>
+
+                            <article class="plan" tabindex="0">
+                                <div class="plan-body">
+                                    <h3 class="plan-title">Ultra</h3>
+                                    <p class="plan-sub">₪199/חודש (מבצע)</p>
+                                    <p class="plan-desc">גישה לכל התכונות הפרימיום ולתמיכה המתקדמת ביותר.</p>
+                                </div>
+                                <div class="plan-footer" aria-hidden="true">→</div>
+                            </article>
+                        </div>
+                    </div>
+                </section>
+                
     </main>
 
     <footer id="main-footer">


### PR DESCRIPTION
Introduce a new Plans/Pricing cards section in index.html with five plan cards (Standard, Plus, Premium, Metal, Ultra), Hebrew labels, keyboard-focusable articles (tabindex), and an ARIA label for the section. Add accompanying styles to index.css: CSS variables for theme, card background/text/muted colors, responsive grid (3/2/1 columns), card layout, hover/focus transforms and shadows, RTL adjustments for the footer arrow, and minor layout/accessibility tweaks. Also reformats the testimonials markup.