### PR TITLE
Bump favicon cache and fix asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="index.css">
         <!-- standard favicon (ICO) -->
-    <link rel="icon" href="/favicon.ico">
+        <link rel="icon" href="favicon.ico?v=2">
     
     <!-- PNG fallback and modern sizes -->
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png?v=2">
+        <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16.png?v=2">
     
     <!-- SVG favicon (modern browsers) -->
-    <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg">
+        <link rel="icon" type="image/svg+xml" href="assets/favicon.svg?v=2">
     
     <!-- Apple touch icon (iOS home screen) -->
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+        <link rel="apple-touch-icon" href="assets/apple-touch-icon.png?v=2">
     <link rel="icon" href="/assets/favicon.svg?v=2">
     <title>DollarTrack AI - מעקב מטבע חכם</title>
 </head>
@@ -24,7 +24,7 @@
         <!-- <div id="logo-placeholder">לוגו DollarTrack AI</div> -->
                
                 <a href="/" id="logo-link" aria-label="DollarTrack AI home">
-                    <img id="site-logo" src="/assets/logo.svg" alt="DollarTrack AI logo" width="160" height="44">
+                    <img id="site-logo" src="assets/logo.svg?v=2" alt="DollarTrack AI logo" width="160" height="44">
                 </a>
         <nav id="main-nav">
             <ul>


### PR DESCRIPTION
Update index.html to use relative asset paths and add cache-busting query params. Switched absolute root paths (e.g. /favicon.ico, /assets/...) to relative paths (favicon.ico, assets/...), moved PNG favicons into assets/, and appended ?v=2 to favicon, SVG, apple-touch-icon and the site logo to force clients to fetch updated resources.